### PR TITLE
Use correct path to hetzner-bootstrap.nix

### DIFF
--- a/nixopshetzner/backends/server.py
+++ b/nixopshetzner/backends/server.py
@@ -231,7 +231,7 @@ class HetznerState(MachineState):
         only mount based on information provided in self.partitions.
         """
         self.log_start("building Nix bootstrap installer... ")
-        expr = os.path.join(self.depl.expr_path, "hetzner-bootstrap.nix")
+        expr = os.path.realpath(os.path.dirname(__file__) + "../../../../../../share/nix/nixops-hetzner/hetzner-bootstrap.nix")
         bootstrap_out = subprocess.check_output(["nix-build", expr,
                                                  "--no-out-link"]).rstrip()
         bootstrap = os.path.join(bootstrap_out, 'bin/hetzner-bootstrap')

--- a/release.nix
+++ b/release.nix
@@ -8,7 +8,7 @@ let
   version = "1.7" +
             (if officialRelease then ""
              else if src ? lastModified then "pre${builtins.substring 0 8 src.lastModified}.${src.shortRev}"
-             else "pre${toString src.revCount}_${src.shortRev}");
+             else "pre${toString (src.revCount or 0)}_${src.shortRev or "abcdef"}");
 in
 
 rec {


### PR DESCRIPTION
... as it has changed after transition to plugin infrastructure.

Current state of the code yields this error:

```
[nix-shell:~/Werk/hetzner]$ nixops deploy -d kretzwerk
kretzner> installing machine...
kretzner> rebooting machine ‘kretzner’ (55.55.55.55) into rescue system
kretzner> sending hard reset to robot... done.
kretzner> waiting for rescue system...[down]..................................[up]
kretzner> building Nix bootstrap installer... error: getting status of '/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/share/nix/nixops/hetzner-bootstrap.nix': No such file or directory
Traceback (most recent call last):
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/bin/.nixops-wrapped", line 246, in <module>
    args.op(args)
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/script_defs.py", line 427, in op_deploy
    max_concurrent_activate=args.max_concurrent_activate)
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1062, in deploy
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1051, in run_with_notify
    f()
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 1062, in <lambda>
    self.run_with_notify('deploy', lambda: self._deploy(**kwargs))
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 999, in _deploy
    nixops.parallel.run_tasks(nr_workers=-1, tasks=self.active_resources.itervalues(), worker_fun=worker)
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/parallel.py", line 44, in thread_fun
    result_queue.put((worker_fun(t), None, t.name))
  File "/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/lib/python2.7/site-packages/nixops/deployment.py", line 972, in worker
    r.create(self.definitions[r.name], check=check, allow_reboot=allow_reboot, allow_recreate=allow_recreate)
  File "/nix/store/wvn68v5xiifxbh8a7him9ag8n8w70drj-nixops-hetzner-1.7pre0_abcdef/lib/python2.7/site-packages/nixopshetzner/backends/server.py", line 633, in create
    self.reboot_rescue(install=True, partitions=defn.partitions)
  File "/nix/store/wvn68v5xiifxbh8a7him9ag8n8w70drj-nixops-hetzner-1.7pre0_abcdef/lib/python2.7/site-packages/nixopshetzner/backends/server.py", line 366, in reboot_rescue
    self._bootstrap_rescue(install, partitions)
  File "/nix/store/wvn68v5xiifxbh8a7him9ag8n8w70drj-nixops-hetzner-1.7pre0_abcdef/lib/python2.7/site-packages/nixopshetzner/backends/server.py", line 236, in _bootstrap_rescue
    "--no-out-link"]).rstrip()
  File "/nix/store/3nrk6w6pm8f515bd2ial11qzsqy5gx03-python-2.7.16/lib/python2.7/subprocess.py", line 223, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['nix-build', '/nix/store/73vva64d3sixfix7q8rcr7w3kw14blw1-nixops-1.7pre0_abcdef/share/nix/nixops/hetzner-bootstrap.nix', '--no-out-link']' returned non-zero exit status 1
```

Note that after applying this fix, I run straight into the issue solved
by https://github.com/nixos/nixops-hetzner/pull/1 (so please merge that 🙃)
