### PR TITLE
update readme to reflect irc change to libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains the NixOps Hetzner Plugin.
 * [Source code](https://github.com/NixOS/nixops)
 * [Issue Tracker](https://github.com/NixOS/nixops/issues)
 * [Mailing list / Google group](https://groups.google.com/forum/#!forum/nixops-users)
-* [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
+* [IRC - #nixos on libera.chat](irc://irc.libera.chat/#nixos)
 * [Documentation](https://nixops.readthedocs.io/en/latest)
 
 ## Developing


### PR DESCRIPTION
nixos irc has moved to libera.chat (see: https://nixos.wiki/wiki/Get_In_Touch), just updating the readme to reflect these changes