### PR TITLE
hetzner-bootstrap: s/stdenv.lib/lib/g

### DIFF
--- a/nixops_hetzner/nix/hetzner-bootstrap.nix
+++ b/nixops_hetzner/nix/hetzner-bootstrap.nix
@@ -142,7 +142,7 @@ in stdenv.mkDerivation {
                        (remember, we're on a non-NixOS system here), together
                        with the partitioner.
     '';
-    platforms = stdenv.lib.platforms.all;
-    maintainers = [ stdenv.lib.maintainers.aszlig ];
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.aszlig ];
   };
 }


### PR DESCRIPTION
As of nixpkgs#d2c9f816e3e8dd1bcb2069276206c19688b62baf the usage of
stdenv.lib has been deprecated, replaced by lib. It was deprecated in 21.05

This PR ensures nixops-hetzner doesn't break on eval for new bootstraps.